### PR TITLE
update deps in pacakge.json, added error listener to stream to reject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ node_modules
 
 # Optional REPL history
 .node_repl_history
+
+package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### v0.0.6 - `September 16th, 2018`
+* Update dependencies in package.json (from npm audit warnings).
+* Add listener to on error if streaming which rejects promise.
+
+
 #### v0.0.5 - `April 11th, 2016`
 * Quick fix for `dustjs-linkedin` peer dependency
 

--- a/index.js
+++ b/index.js
@@ -89,6 +89,7 @@ module.exports = (viewsPath, options) => {
 				if (options.stream === true) {
 					let stream = dust.stream(view, context);
 					let body = ctx.body = new Readable({read: ()=>{}}); // Ensure body is readable stream
+					stream.on('error', (e)=>{ reject(e); }); // reject on error.
 					stream.on('data', (d)=>{ if (d.trim().length > 0) { body.push(d); } }); // Filter out chunks that are just whitespace
 					stream.on('end', ()=>{ body.push(null); resolve(); }); // Ensure the response is terminated and the render is resolved
 				} else {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "koa-dust",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Dustjs-linkedin renderer for koa",
   "files": [
     "index.js"
   ],
   "scripts": {
-    "test": "mocha --compilers js:babel-register --require babel-polyfill"
+    "test": "mocha --require babel-register --exit --require babel-polyfill"
   },
   "dependencies": {
     "dustjs-linkedin": "^2.7.2",
@@ -19,8 +19,8 @@
     "babel-preset-stage-3": "^6.5.0",
     "babel-register": "^6.7.2",
     "koa": "2",
-    "mocha": "2",
-    "supertest": "1"
+    "mocha": "^5.2.0",
+    "supertest": "^3.3.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
1. Updated some package.json dependencies, as there were a handful of audit warnings, and fixed to test script so mocha runs and exits.
2. Added on `error` to stream to reject promise so error happen, they were getting swallowed.
